### PR TITLE
Can build unstable against core16.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,33 @@
-mg Snap Package
-===================
+# mg Snap Package
 
 [![Snap Status](https://build.snapcraft.io/badge/thibran/mg-snap.svg)](https://build.snapcraft.io/user/thibran/mg-snap)
 
 [mg repo](https://github.com/hboetes/mg)
 
 The snap should be build on an Ubuntu 16.04 host.
+If the host is not available, install with:
 
+    sudo snap install --beta core16
 
-Build Steps:
-------------
+The `--beta` switch is needed because there is currently no stable release of `core16`.
+
+## Build Steps
 
 Install Snapcraft:
 
     sudo snap install --classic snapcraft
 
-
 Then run inside the `mg-snap` folder:
 
     snapcraft
 
-
-To install the snap-package:
+To install the snap-package from the local build:
 
     sudo snap install mg-thibran_*.snap --dangerous
 
 The `--dangerous` is necessary because the local build snap is not signed by the snap-store.
 
-
-Alias (optional)
-----------------
+### Alias (optional)
 
 It's possible to create an alias with:
 
@@ -37,9 +35,7 @@ It's possible to create an alias with:
 
 Note: Starting a snap for the first time is takes a bit longer than succeeding launches.
 
-
-Links
-=====
+## Links
 
 [Snapcraft Docs](https://docs.snapcraft.io/)  
 [Snap Build Service](https://build.snapcraft.io/)  

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -10,8 +10,9 @@ description: |
 
   https://man.openbsd.org/mg.1
 
-grade: stable       # stable devel
-confinement: strict # strict devmode
+grade: devel          # stable devel
+confinement: strict    # strict devmode
+base: core16
 
 version-script: |
   cd parts/mg/src
@@ -32,6 +33,7 @@ parts:
       - libbsd-dev
       - libncurses5-dev
       - pkg-config
+      - gcc
     organize:
       usr/local/bin/mg: bin/mg
       usr/local/man/man1/mg.1: usr/share/man/man1/mg.1


### PR DESCRIPTION
Reworked `snapcraft.yaml` so it uses [core16](https://snapcraft.io/core16) to build.

Unfortunately there is no stable release of the core16 snap, so until a stable release is made of core16, no stable builds can be made that uses core16.

I also reworked the README to use more standard markdown.